### PR TITLE
fix(deps): bump minimist from 1.2.5 to 1.2.6

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2598,9 +2598,9 @@ minimatch@^3.0.4:
     brace-expansion "^1.1.7"
 
 minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+  version "1.2.6"
+  resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 ms@2.1.2:
   version "2.1.2"


### PR DESCRIPTION
### Description

Upgraded minimist from 1.2.5 to 1.2.6 to address a security
vulnerability.

### Links

<!--
Replace this comment block with relevant links to project trackers,
like Jira, RPD or GitHub here. Example:

* Fixes #1
* Fixes #2
-->

### Testing

<!--
Replace this comment block with any testing instructions for reviewers. This is in
addition to any acceptance criteria in an associated issue.
-->

### Checklist

Ensure the following things have been met before requesting a review:

* [x] Follows all project developer guide and coding standards.
* [x] Tests have been written for the change, when applicable.
* [x] Confidential information (credentials, auth tokens, etc...) is not included.
