### PR TITLE
feat(proxy): proxy support with ConfidentialClient

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        node-version: [16]
+        node-version: [18]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        node-version: [12, 14, 16]
+        node-version: [16]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
 
       - name: Install dependencies
         run: yarn install

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ async function exampleRequest() {
 exampleRequest();
 ```
 
-## Configure a Proxy
+### Configure a Proxy
 
 You can pass proxy settings to the ConfidentialClient if necessary. The proxy URL can be passed as an object with the proxyUrl property:
 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,7 @@ exampleRequest();
 
 ## Configure a Proxy
 
-You can pass proxy settings to the ConfidentialClient if necessary. The proxy URL can be passed as an object with the
-proxyUrl property:
+You can pass proxy settings to the ConfidentialClient if necessary. The proxy URL can be passed as an object with the proxyUrl property:
 
 ```ts
 const confidentialClient = new ConfidentialClient('/path/to/config.json',{ proxyUrl: 'http://username:password@proxy.example.com:8080' });
@@ -68,10 +67,7 @@ Information about the various utility modules contained in this library can be f
 
 ### Authentication
 
-The [authentication module](src) provides helper classes that
-facilitate [OAuth 2.0](https://developer.factset.com/learn/authentication-oauth2) authentication and authorization with
-FactSet's APIs. Currently, the module has support for
-the [client credentials flow](https://github.com/factset/oauth2-guidelines#client-credentials-flow-1).
+The [authentication module](src) provides helper classes that facilitate [OAuth 2.0](https://developer.factset.com/learn/authentication-oauth2) authentication and authorization with FactSet's APIs. Currently, the module has support for the [client credentials flow](https://github.com/factset/oauth2-guidelines#client-credentials-flow-1).
 
 Each helper class in the module has the following features:
 
@@ -142,7 +138,7 @@ Please refer to the [contributing guide](CONTRIBUTING.md).
 
 ## Copyright
 
-Copyright 2022 FactSet Research Systems Inc
+Copyright 2024 FactSet Research Systems Inc
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ exampleRequest();
 You can pass proxy settings to the ConfidentialClient if necessary. The proxy URL can be passed as an object with the proxyUrl property:
 
 ```ts
-const confidentialClient = new ConfidentialClient('/path/to/config.json',{ proxyUrl: 'http://username:password@proxy.example.com:8080' });
+const confidentialClient = new ConfidentialClient('/path/to/config.json', { proxyUrl: 'http://username:password@proxy.example.com:8080' });
 ```
 
 ## Modules

--- a/README.md
+++ b/README.md
@@ -53,13 +53,25 @@ async function exampleRequest() {
 exampleRequest();
 ```
 
+## Configure a Proxy
+
+You can pass proxy settings to the ConfidentialClient if necessary. The proxy URL can be passed as an object with the
+proxyUrl property:
+
+```ts
+const confidentialClient = new ConfidentialClient('/path/to/config.json',{ proxyUrl:'http://username:password@proxy.example.com:8080' });
+```
+
 ## Modules
 
 Information about the various utility modules contained in this library can be found below.
 
 ### Authentication
 
-The [authentication module](src) provides helper classes that facilitate [OAuth 2.0](https://developer.factset.com/learn/authentication-oauth2) authentication and authorization with FactSet's APIs. Currently the module has support for the [client credentials flow](https://github.com/factset/oauth2-guidelines#client-credentials-flow-1).
+The [authentication module](src) provides helper classes that
+facilitate [OAuth 2.0](https://developer.factset.com/learn/authentication-oauth2) authentication and authorization with
+FactSet's APIs. Currently, the module has support for
+the [client credentials flow](https://github.com/factset/oauth2-guidelines#client-credentials-flow-1).
 
 Each helper class in the module has the following features:
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ You can pass proxy settings to the ConfidentialClient if necessary. The proxy UR
 proxyUrl property:
 
 ```ts
-const confidentialClient = new ConfidentialClient('/path/to/config.json',{ proxyUrl:'http://username:password@proxy.example.com:8080' });
+const confidentialClient = new ConfidentialClient('/path/to/config.json',{ proxyUrl: 'http://username:password@proxy.example.com:8080' });
 ```
 
 ## Modules

--- a/__tests__/confidentialClient.spec.ts
+++ b/__tests__/confidentialClient.spec.ts
@@ -89,8 +89,8 @@ describe('test ConfidentialClient class', () => {
         }),
       } as unknown as Client);
 
-      const confidentialClient = new ConfidentialClient('./__tests__/fixtures/validConfig.json',{
-        proxyUrl:proxyUrl,
+      const confidentialClient = new ConfidentialClient('./__tests__/fixtures/validConfig.json', {
+        proxyUrl: proxyUrl,
       });
 
       await confidentialClient.getAccessToken();

--- a/__tests__/confidentialClient.spec.ts
+++ b/__tests__/confidentialClient.spec.ts
@@ -96,7 +96,7 @@ describe('test ConfidentialClient class', () => {
       await confidentialClient.getAccessToken();
 
       expect(OpenIDClientFactory.getClient).toHaveBeenCalledWith(
-        expect.objectContaining({ proxy: proxyUrl }),
+        expect.objectContaining({ proxyUrl: proxyUrl }),
         new HttpsProxyAgent('http://proxy.example.com:8080'),
       );
     });

--- a/__tests__/confidentialClient.spec.ts
+++ b/__tests__/confidentialClient.spec.ts
@@ -89,7 +89,9 @@ describe('test ConfidentialClient class', () => {
         }),
       } as unknown as Client);
 
-      const confidentialClient = new ConfidentialClient('./__tests__/fixtures/validConfig.json', { proxy: proxyUrl });
+      const confidentialClient = new ConfidentialClient('./__tests__/fixtures/validConfig.json',{
+        proxyUrl:proxyUrl,
+      });
 
       await confidentialClient.getAccessToken();
 

--- a/__tests__/confidentialClient.spec.ts
+++ b/__tests__/confidentialClient.spec.ts
@@ -84,7 +84,8 @@ describe('test ConfidentialClient class', () => {
 
       mocked(OpenIDClientFactory.getClient).mockResolvedValue({
         grant: jest.fn().mockResolvedValue({
-          access_token: 'test_token',expires_at:Math.floor(Date.now() / 1000) + 900,
+          access_token: 'test_token',
+          expires_at: Math.floor(Date.now() / 1000) + 900,
         }),
       } as unknown as Client);
 
@@ -92,7 +93,10 @@ describe('test ConfidentialClient class', () => {
 
       await confidentialClient.getAccessToken();
 
-      expect(OpenIDClientFactory.getClient).toHaveBeenCalledWith(expect.objectContaining({ proxy:proxyUrl }),new HttpsProxyAgent('http://proxy.example.com:8080'));
+      expect(OpenIDClientFactory.getClient).toHaveBeenCalledWith(
+        expect.objectContaining({ proxy: proxyUrl }),
+        new HttpsProxyAgent('http://proxy.example.com:8080'),
+      );
     });
   });
 });

--- a/__tests__/confidentialClient.spec.ts
+++ b/__tests__/confidentialClient.spec.ts
@@ -5,8 +5,8 @@ import { OpenIDClientFactory } from '../src/openIDClientFactory';
 
 jest.mock('../src/openIDClientFactory');
 
-jest.mock('https-proxy-agent',() => {
-  return jest.fn().mockImplementation(function(this: { proxy: string }) {
+jest.mock('https-proxy-agent', () => {
+  return jest.fn().mockImplementation(function (this: { proxy: string }) {
     this.proxy = 'http://proxy.example.com:8080';
   });
 });
@@ -84,15 +84,15 @@ describe('test ConfidentialClient class', () => {
       await expect(confidentialClient.getAccessToken()).rejects.toThrow('Error attempting to get access token');
     });
 
-    test('should use the proxy agent if provided',async () => {
+    test('should use the proxy agent if provided', async () => {
       const proxyUrl = 'http://proxy.example.com:8080';
       mocked(OpenIDClientFactory.getClient).mockResolvedValue({
-        grant:jest.fn().mockResolvedValue({
-          access_token:'test_token',
+        grant: jest.fn().mockResolvedValue({
+          access_token: 'test_token',
         }),
       } as unknown as Client);
 
-      const confidentialClient = new ConfidentialClient('./__tests__/fixtures/validConfig.json',{ proxy:proxyUrl });
+      const confidentialClient = new ConfidentialClient('./__tests__/fixtures/validConfig.json', { proxy: proxyUrl });
 
       await expect(confidentialClient.getAccessToken()).resolves.toBe('test_token');
     });

--- a/__tests__/confidentialClient.spec.ts
+++ b/__tests__/confidentialClient.spec.ts
@@ -96,7 +96,7 @@ describe('test ConfidentialClient class', () => {
       await confidentialClient.getAccessToken();
 
       expect(OpenIDClientFactory.getClient).toHaveBeenCalledWith(
-        expect.objectContaining({ proxyUrl: proxyUrl }),
+        expect.anything(),
         new HttpsProxyAgent('http://proxy.example.com:8080'),
       );
     });

--- a/__tests__/openIDClientFactory.spec.ts
+++ b/__tests__/openIDClientFactory.spec.ts
@@ -1,6 +1,6 @@
 import { OpenIDClientFactory } from '../src/openIDClientFactory';
 import { mocked } from 'ts-jest/utils';
-import { Client,custom,Issuer } from 'openid-client';
+import { Client, custom, Issuer } from 'openid-client';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 
 jest.mock('openid-client');
@@ -47,19 +47,21 @@ describe('Test OpenIDClientFactory class', () => {
       expect(Issuer.discover).toHaveBeenCalledWith('testWellKnownUri');
     });
 
-    test('should not throw an error and set proxy properly',async () => {
+    test('should not throw an error and set proxy properly', async () => {
       const proxyUrl = 'http://proxy.example.com:8080';
 
       mocked(Issuer.discover).mockResolvedValue({
-        metadata:{
-          issuer:'test',token_endpoint:'token_endpoint',
-        },Client:jest.fn().mockReturnValue({
-          grant:jest.fn().mockResolvedValue('testgrant'),
+        metadata: {
+          issuer: 'test',
+          token_endpoint: 'token_endpoint',
+        },
+        Client: jest.fn().mockReturnValue({
+          grant: jest.fn().mockResolvedValue('testgrant'),
         }),
       } as unknown as Issuer<Client>);
 
-      await OpenIDClientFactory.getClient(config,new HttpsProxyAgent(proxyUrl));
-      expect(custom.setHttpOptionsDefaults).toHaveBeenCalledWith({ agent:new HttpsProxyAgent(proxyUrl) });
+      await OpenIDClientFactory.getClient(config, new HttpsProxyAgent(proxyUrl));
+      expect(custom.setHttpOptionsDefaults).toHaveBeenCalledWith({ agent: new HttpsProxyAgent(proxyUrl) });
     });
 
     test('should throw an error while retrieving contents from well known uri', async () => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@factset/sdk-utils",
   "description": "Utilities for interacting with FactSet APIs.",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "homepage": "https://developer.factset.com",
   "repository": "FactSet/enterprise-sdk-utils-typescript.git",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "FactSet Research Systems",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "keywords": [
     "FactSet",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,9 @@
   ],
   "dependencies": {
     "debug": "^4.3.4",
-    "jose": "^4.15.4",
+    "http-proxy-agent": "^7.0.2",
     "joi": "^17.12.3",
+    "jose": "^4.15.4",
     "openid-client": "^5.6.5"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "FactSet Research Systems",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=12"
+    "node": ">=16"
   },
   "keywords": [
     "FactSet",

--- a/src/confidentialClient.ts
+++ b/src/confidentialClient.ts
@@ -1,8 +1,8 @@
-import { AccessTokenError, ConfidentialClientConfiguration, OAuth2Client, Token } from '.';
+import { AccessTokenError,ConfidentialClientConfiguration,OAuth2Client,Token } from '.';
 import { OpenIDClientFactory } from './openIDClientFactory';
 import { Configuration } from './configuration';
 import { Client } from 'openid-client';
-import { JWT_EXPIRE_AFTER_SECS, JWT_NOT_BEFORE_SECS, PACKAGE_NAME } from './constants';
+import { JWT_EXPIRE_AFTER_SECS,JWT_NOT_BEFORE_SECS,PACKAGE_NAME } from './constants';
 import { unixTimestamp } from './unixTimestamp';
 import debugModule from 'debug';
 import { HttpsProxyAgent } from 'https-proxy-agent';
@@ -26,7 +26,7 @@ export class ConfidentialClient implements OAuth2Client {
    * @param path Path to credentials configuration file.
    * @param agent Proxy agent to use for requests.
    */
-  constructor(path: string, agent?: { proxy: string });
+  constructor(path: string,agent?: { proxyUrl: string });
 
   /**
    * Example config
@@ -57,11 +57,11 @@ export class ConfidentialClient implements OAuth2Client {
    * @param config FacSet ConfidentialClient configuration object
    */
   constructor(config: ConfidentialClientConfiguration);
-  constructor(param: ConfidentialClientConfiguration | string, agent?: { proxy: string }) {
+  constructor(param: ConfidentialClientConfiguration | string,agent?: { proxyUrl: string }) {
     this._config = Configuration.loadConfig(param);
     this._token = new Token('', 0);
     if (agent) {
-      this._config.proxy = agent?.proxy;
+      this._config.proxyUrl = agent?.proxyUrl;
     }
   }
 
@@ -86,8 +86,8 @@ export class ConfidentialClient implements OAuth2Client {
     }
     debug('Token is expired or invalid');
 
-    if (this._config.proxy) {
-      const proxyAgent = new HttpsProxyAgent(`${this._config.proxy}`);
+    if (this._config.proxyUrl) {
+      const proxyAgent = new HttpsProxyAgent(`${this._config.proxyUrl}`);
 
       this._openIDClient = await OpenIDClientFactory.getClient(this._config, proxyAgent);
     } else {

--- a/src/confidentialClient.ts
+++ b/src/confidentialClient.ts
@@ -1,8 +1,8 @@
-import { AccessTokenError,ConfidentialClientConfiguration,OAuth2Client,Token } from '.';
+import { AccessTokenError, ConfidentialClientConfiguration, OAuth2Client, Token } from '.';
 import { OpenIDClientFactory } from './openIDClientFactory';
 import { Configuration } from './configuration';
 import { Client } from 'openid-client';
-import { JWT_EXPIRE_AFTER_SECS,JWT_NOT_BEFORE_SECS,PACKAGE_NAME } from './constants';
+import { JWT_EXPIRE_AFTER_SECS, JWT_NOT_BEFORE_SECS, PACKAGE_NAME } from './constants';
 import { unixTimestamp } from './unixTimestamp';
 import debugModule from 'debug';
 import { HttpsProxyAgent } from 'https-proxy-agent';
@@ -26,7 +26,7 @@ export class ConfidentialClient implements OAuth2Client {
    * @param path Path to credentials configuration file.
    * @param agent Proxy agent to use for requests.
    */
-  constructor(path: string,agent?: { proxyUrl: string });
+  constructor(path: string, agent?: { proxyUrl: string });
 
   /**
    * Example config
@@ -57,7 +57,7 @@ export class ConfidentialClient implements OAuth2Client {
    * @param config FacSet ConfidentialClient configuration object
    */
   constructor(config: ConfidentialClientConfiguration);
-  constructor(param: ConfidentialClientConfiguration | string,agent?: { proxyUrl: string }) {
+  constructor(param: ConfidentialClientConfiguration | string, agent?: { proxyUrl: string }) {
     this._config = Configuration.loadConfig(param);
     this._token = new Token('', 0);
     if (agent) {

--- a/src/confidentialClient.ts
+++ b/src/confidentialClient.ts
@@ -1,11 +1,11 @@
-import { AccessTokenError, ConfidentialClientConfiguration, OAuth2Client, Token } from '.';
+import { AccessTokenError,ConfidentialClientConfiguration,OAuth2Client,Token } from '.';
 import { OpenIDClientFactory } from './openIDClientFactory';
 import { Configuration } from './configuration';
 import { Client } from 'openid-client';
-import { JWT_EXPIRE_AFTER_SECS, JWT_NOT_BEFORE_SECS, PACKAGE_NAME } from './constants';
+import { JWT_EXPIRE_AFTER_SECS,JWT_NOT_BEFORE_SECS,PACKAGE_NAME } from './constants';
 import { unixTimestamp } from './unixTimestamp';
 import debugModule from 'debug';
-import HttpsProxyAgent from 'https-proxy-agent';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 
 const debug = debugModule(`${PACKAGE_NAME}:ConfidentialClient`);
 
@@ -87,7 +87,7 @@ export class ConfidentialClient implements OAuth2Client {
     debug('Token is expired or invalid');
 
     if (this._config.proxy) {
-      const proxyAgent = HttpsProxyAgent(`${this._config.proxy}`);
+      const proxyAgent = new HttpsProxyAgent(`${this._config.proxy}`);
 
       this._openIDClient = await OpenIDClientFactory.getClient(this._config, proxyAgent);
     } else {

--- a/src/confidentialClient.ts
+++ b/src/confidentialClient.ts
@@ -1,10 +1,12 @@
-import { Token, AccessTokenError, ConfidentialClientConfiguration, OAuth2Client } from '.';
+import { AccessTokenError,ConfidentialClientConfiguration,OAuth2Client,Token } from '.';
 import { OpenIDClientFactory } from './openIDClientFactory';
 import { Configuration } from './configuration';
 import { Client } from 'openid-client';
-import { PACKAGE_NAME, JWT_NOT_BEFORE_SECS, JWT_EXPIRE_AFTER_SECS } from './constants';
+import { JWT_EXPIRE_AFTER_SECS,JWT_NOT_BEFORE_SECS,PACKAGE_NAME } from './constants';
 import { unixTimestamp } from './unixTimestamp';
 import debugModule from 'debug';
+import HttpsProxyAgent from 'https-proxy-agent';
+
 const debug = debugModule(`${PACKAGE_NAME}:ConfidentialClient`);
 
 /**
@@ -22,8 +24,9 @@ export class ConfidentialClient implements OAuth2Client {
 
   /**
    * @param path Path to credentials configuration file.
+   * @param agent Proxy agent to use for requests.
    */
-  constructor(path: string);
+  constructor(path: string,agent?: { proxy: string });
 
   /**
    * Example config
@@ -54,9 +57,12 @@ export class ConfidentialClient implements OAuth2Client {
    * @param config FacSet ConfidentialClient configuration object
    */
   constructor(config: ConfidentialClientConfiguration);
-  constructor(param: ConfidentialClientConfiguration | string) {
+  constructor(param: ConfidentialClientConfiguration | string,agent?: { proxy: string }) {
     this._config = Configuration.loadConfig(param);
     this._token = new Token('', 0);
+    if (agent) {
+      this._config.proxy = agent?.proxy;
+    }
   }
 
   /**
@@ -80,7 +86,11 @@ export class ConfidentialClient implements OAuth2Client {
     }
     debug('Token is expired or invalid');
 
-    if (this._openIDClient === undefined) {
+    if (this._config.proxy) {
+      const proxyAgent = HttpsProxyAgent(`${this._config.proxy}`);
+
+      this._openIDClient = await OpenIDClientFactory.getClient(this._config,proxyAgent);
+    } else {
       this._openIDClient = await OpenIDClientFactory.getClient(this._config);
     }
 

--- a/src/confidentialClient.ts
+++ b/src/confidentialClient.ts
@@ -21,12 +21,13 @@ export class ConfidentialClient implements OAuth2Client {
   private readonly _config: ConfidentialClientConfiguration;
   private _token: Token;
   private _openIDClient!: Client;
+  private _options: { proxyUrl: string } | null;
 
   /**
    * @param path Path to credentials configuration file.
-   * @param agent Proxy agent to use for requests.
+   * @param _options HTTP proxy options.
    */
-  constructor(path: string, agent?: { proxyUrl: string });
+  constructor(path: string, _options?: { proxyUrl: string });
 
   /**
    * Example config
@@ -57,12 +58,10 @@ export class ConfidentialClient implements OAuth2Client {
    * @param config FacSet ConfidentialClient configuration object
    */
   constructor(config: ConfidentialClientConfiguration);
-  constructor(param: ConfidentialClientConfiguration | string, agent?: { proxyUrl: string }) {
+  constructor(param: ConfidentialClientConfiguration | string, _options?: { proxyUrl: string }) {
     this._config = Configuration.loadConfig(param);
     this._token = new Token('', 0);
-    if (agent) {
-      this._config.proxyUrl = agent?.proxyUrl;
-    }
+    this._options = _options ?? null;
   }
 
   /**
@@ -86,8 +85,8 @@ export class ConfidentialClient implements OAuth2Client {
     }
     debug('Token is expired or invalid');
 
-    if (this._config.proxyUrl) {
-      const proxyAgent = new HttpsProxyAgent(`${this._config.proxyUrl}`);
+    if (this._options?.proxyUrl) {
+      const proxyAgent = new HttpsProxyAgent(`${this._options.proxyUrl}`);
 
       this._openIDClient = await OpenIDClientFactory.getClient(this._config, proxyAgent);
     } else {

--- a/src/confidentialClient.ts
+++ b/src/confidentialClient.ts
@@ -1,8 +1,8 @@
-import { AccessTokenError,ConfidentialClientConfiguration,OAuth2Client,Token } from '.';
+import { AccessTokenError, ConfidentialClientConfiguration, OAuth2Client, Token } from '.';
 import { OpenIDClientFactory } from './openIDClientFactory';
 import { Configuration } from './configuration';
 import { Client } from 'openid-client';
-import { JWT_EXPIRE_AFTER_SECS,JWT_NOT_BEFORE_SECS,PACKAGE_NAME } from './constants';
+import { JWT_EXPIRE_AFTER_SECS, JWT_NOT_BEFORE_SECS, PACKAGE_NAME } from './constants';
 import { unixTimestamp } from './unixTimestamp';
 import debugModule from 'debug';
 import { HttpsProxyAgent } from 'https-proxy-agent';

--- a/src/confidentialClient.ts
+++ b/src/confidentialClient.ts
@@ -1,8 +1,8 @@
-import { AccessTokenError,ConfidentialClientConfiguration,OAuth2Client,Token } from '.';
+import { AccessTokenError, ConfidentialClientConfiguration, OAuth2Client, Token } from '.';
 import { OpenIDClientFactory } from './openIDClientFactory';
 import { Configuration } from './configuration';
 import { Client } from 'openid-client';
-import { JWT_EXPIRE_AFTER_SECS,JWT_NOT_BEFORE_SECS,PACKAGE_NAME } from './constants';
+import { JWT_EXPIRE_AFTER_SECS, JWT_NOT_BEFORE_SECS, PACKAGE_NAME } from './constants';
 import { unixTimestamp } from './unixTimestamp';
 import debugModule from 'debug';
 import HttpsProxyAgent from 'https-proxy-agent';
@@ -26,7 +26,7 @@ export class ConfidentialClient implements OAuth2Client {
    * @param path Path to credentials configuration file.
    * @param agent Proxy agent to use for requests.
    */
-  constructor(path: string,agent?: { proxy: string });
+  constructor(path: string, agent?: { proxy: string });
 
   /**
    * Example config
@@ -57,7 +57,7 @@ export class ConfidentialClient implements OAuth2Client {
    * @param config FacSet ConfidentialClient configuration object
    */
   constructor(config: ConfidentialClientConfiguration);
-  constructor(param: ConfidentialClientConfiguration | string,agent?: { proxy: string }) {
+  constructor(param: ConfidentialClientConfiguration | string, agent?: { proxy: string }) {
     this._config = Configuration.loadConfig(param);
     this._token = new Token('', 0);
     if (agent) {
@@ -89,7 +89,7 @@ export class ConfidentialClient implements OAuth2Client {
     if (this._config.proxy) {
       const proxyAgent = HttpsProxyAgent(`${this._config.proxy}`);
 
-      this._openIDClient = await OpenIDClientFactory.getClient(this._config,proxyAgent);
+      this._openIDClient = await OpenIDClientFactory.getClient(this._config, proxyAgent);
     } else {
       this._openIDClient = await OpenIDClientFactory.getClient(this._config);
     }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,9 +1,10 @@
 import joi from 'joi';
 import * as jose from 'jose';
 import { ConfigurationError } from './errors';
-import { FACTSET_WELL_KNOWN_URI, PACKAGE_NAME } from './constants';
+import { FACTSET_WELL_KNOWN_URI,PACKAGE_NAME } from './constants';
 import { readFileSync } from 'fs';
 import debugModule from 'debug';
+
 const debug = debugModule(`${PACKAGE_NAME}:configuration`);
 
 export type ConfidentialClientJwk = jose.JWK;
@@ -12,9 +13,7 @@ export type ConfidentialClientConfiguration = {
   name: string;
   clientId: string;
   clientAuthType: string;
-  owners: Array<string>;
-  wellKnownUri: string;
-  jwk: ConfidentialClientJwk;
+  owners: Array<string>;wellKnownUri: string;jwk: ConfidentialClientJwk;proxy?: string;
 };
 
 const schema = joi.object({

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,7 +1,7 @@
 import joi from 'joi';
 import * as jose from 'jose';
 import { ConfigurationError } from './errors';
-import { FACTSET_WELL_KNOWN_URI, PACKAGE_NAME } from './constants';
+import { FACTSET_WELL_KNOWN_URI,PACKAGE_NAME } from './constants';
 import { readFileSync } from 'fs';
 import debugModule from 'debug';
 
@@ -15,8 +15,7 @@ export type ConfidentialClientConfiguration = {
   clientAuthType: string;
   owners: Array<string>;
   wellKnownUri: string;
-  jwk: ConfidentialClientJwk;
-  proxy?: string;
+  jwk: ConfidentialClientJwk;proxyUrl?: string;
 };
 
 const schema = joi.object({

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,7 +1,7 @@
 import joi from 'joi';
 import * as jose from 'jose';
 import { ConfigurationError } from './errors';
-import { FACTSET_WELL_KNOWN_URI,PACKAGE_NAME } from './constants';
+import { FACTSET_WELL_KNOWN_URI, PACKAGE_NAME } from './constants';
 import { readFileSync } from 'fs';
 import debugModule from 'debug';
 
@@ -13,7 +13,10 @@ export type ConfidentialClientConfiguration = {
   name: string;
   clientId: string;
   clientAuthType: string;
-  owners: Array<string>;wellKnownUri: string;jwk: ConfidentialClientJwk;proxy?: string;
+  owners: Array<string>;
+  wellKnownUri: string;
+  jwk: ConfidentialClientJwk;
+  proxy?: string;
 };
 
 const schema = joi.object({

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -16,7 +16,6 @@ export type ConfidentialClientConfiguration = {
   owners: Array<string>;
   wellKnownUri: string;
   jwk: ConfidentialClientJwk;
-  proxyUrl?: string;
 };
 
 const schema = joi.object({

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,7 +1,7 @@
 import joi from 'joi';
 import * as jose from 'jose';
 import { ConfigurationError } from './errors';
-import { FACTSET_WELL_KNOWN_URI,PACKAGE_NAME } from './constants';
+import { FACTSET_WELL_KNOWN_URI, PACKAGE_NAME } from './constants';
 import { readFileSync } from 'fs';
 import debugModule from 'debug';
 
@@ -15,7 +15,8 @@ export type ConfidentialClientConfiguration = {
   clientAuthType: string;
   owners: Array<string>;
   wellKnownUri: string;
-  jwk: ConfidentialClientJwk;proxyUrl?: string;
+  jwk: ConfidentialClientJwk;
+  proxyUrl?: string;
 };
 
 const schema = joi.object({

--- a/src/openIDClientFactory.ts
+++ b/src/openIDClientFactory.ts
@@ -1,14 +1,22 @@
-import { ConfidentialClientConfiguration, WellKnownURIError } from '.';
-import { Client, Issuer, ClientAuthMethod } from 'openid-client';
+import { ConfidentialClientConfiguration,WellKnownURIError } from '.';
+import { Client,ClientAuthMethod,custom,Issuer } from 'openid-client';
 import debugModule from 'debug';
 import { PACKAGE_NAME } from './constants';
+import { Agent } from 'node:http';
+
 const debug = debugModule(`${PACKAGE_NAME}:OpenIDClientFactory`);
 
 export class OpenIDClientFactory {
-  public static async getClient(config: ConfidentialClientConfiguration): Promise<Client> {
+  public static async getClient(config: ConfidentialClientConfiguration,proxyAgent?: Agent): Promise<Client> {
     const jwks = {
       keys: [config.jwk],
     };
+
+    if (proxyAgent) {
+      custom.setHttpOptionsDefaults({
+        agent:proxyAgent,
+      });
+    }
 
     const clientAuthMethod: ClientAuthMethod = 'private_key_jwt';
 

--- a/src/openIDClientFactory.ts
+++ b/src/openIDClientFactory.ts
@@ -1,5 +1,5 @@
-import { ConfidentialClientConfiguration,WellKnownURIError } from '.';
-import { Client,ClientAuthMethod,custom,Issuer } from 'openid-client';
+import { ConfidentialClientConfiguration, WellKnownURIError } from '.';
+import { Client, ClientAuthMethod, custom, Issuer } from 'openid-client';
 import debugModule from 'debug';
 import { PACKAGE_NAME } from './constants';
 import { Agent } from 'node:http';
@@ -7,14 +7,14 @@ import { Agent } from 'node:http';
 const debug = debugModule(`${PACKAGE_NAME}:OpenIDClientFactory`);
 
 export class OpenIDClientFactory {
-  public static async getClient(config: ConfidentialClientConfiguration,proxyAgent?: Agent): Promise<Client> {
+  public static async getClient(config: ConfidentialClientConfiguration, proxyAgent?: Agent): Promise<Client> {
     const jwks = {
       keys: [config.jwk],
     };
 
     if (proxyAgent) {
       custom.setHttpOptionsDefaults({
-        agent:proxyAgent,
+        agent: proxyAgent,
       });
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1092,6 +1092,13 @@ agent-base@6:
   dependencies:
     debug "4"
 
+agent-base@^7.1.0:
+  version "7.1.1"
+  resolved "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz#bdbded7dfb096b751a2a087eeeb9664725b2e317"
+  integrity sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==
+  dependencies:
+    debug "^4.3.4"
+
 ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
@@ -1939,6 +1946,14 @@ http-proxy-agent@^4.0.1:
     "@tootallnate/once" "1"
     agent-base "6"
     debug "4"
+
+http-proxy-agent@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz#9a8b1f246866c028509486585f62b8f2c18c270e"
+  integrity sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==
+  dependencies:
+    agent-base "^7.1.0"
+    debug "^4.3.4"
 
 https-proxy-agent@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
### Description
Adds proxy support for the utils. Updated the docs on how
to set up the proxy. Tests have also been added to check for proxy
<!--
Replace this comment block with detailed description detailed description
of **what** is being changed and **why**.

Here's an example of a good change description:

Added the ability to notify users when a new blog post is made
so that users can be made aware of new features as they become
available.

Used the subscription module to allow users to subscribe to
the various product categories that they are interested in. Emails
are being sent using the smtp module, configured to use FactSet's
standard smtp server.
-->

### Links
ENSC-1337

<!--
Replace this comment block with relevant links to project trackers,
like Jira, RPD or GitHub here. Example:

* Fixes #1
* Fixes #2
-->

### Testing
![image](https://github.com/factset/enterprise-sdk-utils-typescript/assets/101813290/fdfd472a-f269-4787-8b7f-3b2063757bfb)


<!--
Replace this comment block with any testing instructions for reviewers. This is in
addition to any acceptance criteria in an associated issue.
-->

### Checklist

Ensure the following things have been met before requesting a review:

* [x] Follows all project developer guide and coding standards.
* [x] Tests have been written for the change, when applicable.
* [x] Confidential information (credentials, auth tokens, etc...) is not included.
