### PR TITLE
fix(deps): correct missing listing on https-proxy-agent

### DIFF
--- a/__tests__/openIDClientFactory.spec.ts
+++ b/__tests__/openIDClientFactory.spec.ts
@@ -60,8 +60,9 @@ describe('Test OpenIDClientFactory class', () => {
         }),
       } as unknown as Issuer<Client>);
 
-      await OpenIDClientFactory.getClient(config, new HttpsProxyAgent(proxyUrl));
-      expect(custom.setHttpOptionsDefaults).toHaveBeenCalledWith({ agent: new HttpsProxyAgent(proxyUrl) });
+      const agent = new HttpsProxyAgent(proxyUrl);
+      await OpenIDClientFactory.getClient(config, agent);
+      expect(custom.setHttpOptionsDefaults).toHaveBeenCalledWith({ agent });
     });
 
     test('should throw an error while retrieving contents from well known uri', async () => {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "debug": "^4.3.4",
-    "http-proxy-agent": "^7.0.2",
+    "https-proxy-agent": "^7.0.2",
     "joi": "^17.13.1",
     "jose": "^4.15.4",
     "openid-client": "^5.6.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1092,7 +1092,7 @@ agent-base@6:
   dependencies:
     debug "4"
 
-agent-base@^7.1.0:
+agent-base@^7.0.2:
   version "7.1.1"
   resolved "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz#bdbded7dfb096b751a2a087eeeb9664725b2e317"
   integrity sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==
@@ -1947,20 +1947,20 @@ http-proxy-agent@^4.0.1:
     agent-base "6"
     debug "4"
 
-http-proxy-agent@^7.0.2:
-  version "7.0.2"
-  resolved "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz#9a8b1f246866c028509486585f62b8f2c18c270e"
-  integrity sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==
-  dependencies:
-    agent-base "^7.1.0"
-    debug "^4.3.4"
-
 https-proxy-agent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
   integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
   dependencies:
     agent-base "6"
+    debug "4"
+
+https-proxy-agent@^7.0.2:
+  version "7.0.4"
+  resolved "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz#8e97b841a029ad8ddc8731f26595bad868cb4168"
+  integrity sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==
+  dependencies:
+    agent-base "^7.0.2"
     debug "4"
 
 human-signals@^2.1.0:


### PR DESCRIPTION
- mistakenly listed http-proxy-agent when developing the confidentialClient feature
- rework some specs that were relying on object equality, not sure how they passed previously

fixes #518

### Description

<!--
Replace this comment block with detailed description detailed description
of **what** is being changed and **why**.

Here's an example of a good change description:

Added the ability to notify users when a new blog post is made
so that users can be made aware of new features as they become
available.

Used the subscription module to allow users to subscribe to
the various product categories that they are interested in. Emails
are being sent using the smtp module, configured to use FactSet's
standard smtp server.
-->

### Links

<!--
Replace this comment block with relevant links to project trackers,
like Jira, RPD or GitHub here. Example:

* Fixes #1
* Fixes #2
-->

### Testing

<!--
Replace this comment block with any testing instructions for reviewers. This is in
addition to any acceptance criteria in an associated issue.
-->

### Checklist

Ensure the following things have been met before requesting a review:

* [x] Follows all project developer guide and coding standards.
* [x] Tests have been written for the change, when applicable.
* [x] Confidential information (credentials, auth tokens, etc...) is not included.
