### PR TITLE
fix(schema): allow top level unknown properties

### DIFF
--- a/__tests__/configuration.spec.ts
+++ b/__tests__/configuration.spec.ts
@@ -1,4 +1,5 @@
 import {Configuration} from '../src/configuration';
+import {describe} from 'node:test';
 
 const validTestConfig = {
   name: 'name',
@@ -36,6 +37,12 @@ describe('test validateConfig function', () => {
     }).toThrow(
       'Configuration is not valid: "name" is required. "clientId" is required. "clientAuthType" is required. "owners" is required. "jwk" is required'
     );
+  });
+
+  test('should accept and preserve unknown top-level properties', () => {
+    const configWithExtras = {...validTestConfig, scope: 'all', futureOption: {enabled: true}};
+    const config = Configuration.validateConfig(configWithExtras);
+    expect(config).toEqual(configWithExtras);
   });
 });
 

--- a/__tests__/configuration.spec.ts
+++ b/__tests__/configuration.spec.ts
@@ -40,7 +40,7 @@ describe('test validateConfig function', () => {
   });
 
   test('should accept and preserve unknown top-level properties', () => {
-    const configWithExtras = {...validTestConfig, scope: 'all', futureOption: {enabled: true}};
+    const configWithExtras = {...validTestConfig, scope: 'all', futureOption: {x: true}};
     const config = Configuration.validateConfig(configWithExtras);
     expect(config).toEqual(configWithExtras);
   });

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -18,29 +18,31 @@ export type ConfidentialClientConfiguration = {
   jwk: ConfidentialClientJwk;
 };
 
-const schema = joi.object({
-  name: joi.string().required(),
-  clientId: joi.string().required(),
-  clientAuthType: joi.string().required(),
-  owners: joi.array().items(joi.string()).min(1).required(),
-  wellKnownUri: joi.string().uri().default(FACTSET_WELL_KNOWN_URI),
-  jwk: joi
-    .object({
-      kty: joi.string().required(),
-      use: joi.string().required(),
-      alg: joi.string().required(),
-      kid: joi.string().required(),
-      d: joi.string().required(),
-      n: joi.string().required(),
-      e: joi.string().required(),
-      p: joi.string().required(),
-      q: joi.string().required(),
-      dp: joi.string().required(),
-      dq: joi.string().required(),
-      qi: joi.string().required(),
-    })
-    .required(),
-});
+const schema = joi
+  .object({
+    name: joi.string().required(),
+    clientId: joi.string().required(),
+    clientAuthType: joi.string().required(),
+    owners: joi.array().items(joi.string()).min(1).required(),
+    wellKnownUri: joi.string().uri().default(FACTSET_WELL_KNOWN_URI),
+    jwk: joi
+      .object({
+        kty: joi.string().required(),
+        use: joi.string().required(),
+        alg: joi.string().required(),
+        kid: joi.string().required(),
+        d: joi.string().required(),
+        n: joi.string().required(),
+        e: joi.string().required(),
+        p: joi.string().required(),
+        q: joi.string().required(),
+        dp: joi.string().required(),
+        dq: joi.string().required(),
+        qi: joi.string().required(),
+      })
+      .required(),
+  })
+  .unknown(true);
 
 export class Configuration {
   public static validateConfig(config: unknown): ConfidentialClientConfiguration {


### PR DESCRIPTION
### Description

Changes the validation schema to allow top level unknown properties, so it doesn't error out on future properties introduced to the config. This is in preparation for the new `scopes` property that will be introduced.

### Links

ENSC-2740

### Testing

Run unit tests. Also tried locally, and this worked fine.

### Checklist

Ensure the following things have been met before requesting a review:

- [x] Follows all project developer guide and coding standards.
- [x] Tests have been written for the change, when applicable.
- [x] Confidential information (credentials, auth tokens, etc...) is not included.
