### PR TITLE
chore: add bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,5 +54,8 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3"
   },
-  "packageManager": "yarn@4.12.0"
+  "packageManager": "yarn@4.12.0",
+  "bugs": {
+    "url": "https://github.com/factset/enterprise-sdk-utils-typescript/issues"
+  }
 }


### PR DESCRIPTION
## Summary
- add npm bugs metadata for @factset/sdk-utils so package tooling can link to the GitHub issue tracker

## Validation
- npm view @factset/sdk-utils@2.1.4 name version repository homepage bugs license --json
- verified the fork branch package manifest has bugs.url = https://github.com/factset/enterprise-sdk-utils-typescript/issues
- verified the branch is 1 commit ahead and only changes package.json

Charles microbounty: https://github.com/charles-openclaw/charles-microbounties/issues/1179

Note: the Charles issue body points to factset/enterprise-sdk, but the current published npm package metadata points to FactSet/enterprise-sdk-utils-typescript.git, so this PR targets the current package repository.